### PR TITLE
[codex] Add GitHub Pages PR previews

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,10 +41,44 @@ jobs:
       - name: Build
         run: yarn build:prod
 
+      - name: Prepare Pages contents
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mkdir site
+          git init site
+          cd site
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git fetch origin gh-pages --depth=1; then
+            git checkout -B gh-pages FETCH_HEAD
+          else
+            git checkout --orphan gh-pages
+          fi
+
+          find . -mindepth 1 -maxdepth 1 ! -name .git ! -name pr-preview -exec rm -rf {} +
+          cp -R ../dist/. .
+          touch .nojekyll
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+
+          if git diff --cached --quiet; then
+            echo "No production Pages changes to commit."
+          else
+            git commit -m "Deploy production site"
+            git push origin gh-pages
+          fi
+
+          rm -rf .git
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: site
 
   deploy:
     environment:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,202 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment:
+      name: pr-preview-${{ github.event.number }}
+      url: ${{ steps.deployment.outputs.page_url }}pr-preview/pr-${{ github.event.number }}/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build:prod
+
+      - name: Prepare preview contents
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PREVIEW_DIR: pr-preview/pr-${{ github.event.number }}
+        run: |
+          set -euo pipefail
+
+          mkdir site
+          git init site
+          cd site
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git fetch origin gh-pages --depth=1; then
+            git checkout -B gh-pages FETCH_HEAD
+          else
+            git checkout --orphan gh-pages
+          fi
+
+          rm -rf "${PREVIEW_DIR}"
+          mkdir -p "${PREVIEW_DIR}"
+          cp -R ../dist/. "${PREVIEW_DIR}/"
+          touch .nojekyll
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+
+          if git diff --cached --quiet; then
+            echo "No preview Pages changes to commit."
+          else
+            git commit -m "Deploy PR #${{ github.event.number }} preview"
+            git push origin gh-pages
+          fi
+
+          rm -rf .git
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Comment preview link
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deployment.outputs.page_url }}pr-preview/pr-${{ github.event.number }}/
+        with:
+          script: |
+            const marker = '<!-- pr-preview-link -->';
+            const body = `${marker}\nPR preview: ${process.env.PREVIEW_URL}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existing = comments.find((comment) => comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Remove preview contents
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PREVIEW_DIR: pr-preview/pr-${{ github.event.number }}
+        run: |
+          set -euo pipefail
+
+          mkdir site
+          git init site
+          cd site
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git fetch origin gh-pages --depth=1; then
+            git checkout -B gh-pages FETCH_HEAD
+          else
+            echo "No gh-pages branch exists yet. Nothing to clean up."
+            touch .nojekyll
+            rm -rf .git
+            exit 0
+          fi
+
+          rm -rf "${PREVIEW_DIR}"
+          touch .nojekyll
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+
+          if git diff --cached --quiet; then
+            echo "No preview Pages changes to commit."
+          else
+            git commit -m "Remove PR #${{ github.event.number }} preview"
+            git push origin gh-pages
+          fi
+
+          rm -rf .git
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Comment preview removal
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- pr-preview-link -->';
+            const body = `${marker}\nPR preview removed because this PR is closed.`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existing = comments.find((comment) => comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ This is a my personal website. You can pay me a vist at  [https://www.maosen-che
 The site deploys to GitHub Pages from `.github/workflows/pages.yml`. In the repository settings, set
 Pages > Build and deployment > Source to `GitHub Actions`; every push to `master` will then build and publish
 the `dist` directory.
+
+Pull requests opened from branches in this repository also get a preview deployment from
+`.github/workflows/pr-preview.yml`. The workflow builds the PR, publishes it under
+`/pr-preview/pr-<number>/`, comments the preview link on the PR, and removes that preview when the PR closes.


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds same-repo pull requests and deploys them under /pr-preview/pr-<number>/ on GitHub Pages.
- Update the production Pages workflow so production deploys preserve existing PR preview folders.
- Document the preview deployment behavior in the README.

## Impact
PRs opened from branches in this repository will receive a Pages preview link as a sticky PR comment. Closing a PR removes its preview folder. Fork PR previews are intentionally skipped because GitHub does not safely grant Pages/comment write permissions to forked pull requests.

## Validation
- yarn build:prod
- git diff --check
- pre-commit hook ran yarn lint and yarn format